### PR TITLE
rjust takes the desired length of the entire string

### DIFF
--- a/ach/data_types.py
+++ b/ach/data_types.py
@@ -35,8 +35,7 @@ class Ach(object):
         """
 
         if len(field) != length:
-            spaces_needed = length - len(field)
-            return field.rjust(spaces_needed)
+            return field.rjust(length)
         else:
             return field
 


### PR DESCRIPTION
not sure how this was missed, perhaps banks are forgiving. But without this change the routing numbers don't get right justified and the record length is 92 (should be 94).
