### PR TITLE
Add optional CR/LF line endings

### DIFF
--- a/ach/builder.py
+++ b/ach/builder.py
@@ -169,15 +169,14 @@ class AchFile(object):
 
         return credit_amount
 
-    def get_nines(self, rows):
+    def get_nines(self, rows, line_ending):
         nines = ''
 
         for i in range(rows):
-            for l in range(94):
-                nines += '9'
+            nines += '9'*94
             if i == rows - 1:
                 continue
-            nines += "\n"
+            nines += line_ending
 
         return nines
 
@@ -192,23 +191,26 @@ class AchFile(object):
 
         return entry_desc
 
-    def render_to_string(self):
+    def render_to_string(self, force_crlf=False):
         """
         Renders a nacha file as a string
         """
+        line_ending = "\n"
+        if force_crlf:
+            line_ending = "\r\n"
 
-        ret_string = self.header.get_row() + "\n"
+        ret_string = self.header.get_row() + line_ending
 
         for batch in self.batches:
-            ret_string += batch.render_to_string()
+            ret_string += batch.render_to_string(force_crlf=force_crlf)
 
-        ret_string += self.control.get_row() + "\n"
+        ret_string += self.control.get_row() + line_ending
 
         lines = self.get_lines(self.batches)
 
         nine_lines = int(round(10 * (math.ceil(lines / 10.0) - (lines / 10.0))))
 
-        ret_string += self.get_nines(nine_lines)
+        ret_string += self.get_nines(nine_lines, line_ending)
 
         return ret_string
 
@@ -286,17 +288,20 @@ class FileBatch(object):
 
         return credit_amount
 
-    def render_to_string(self):
+    def render_to_string(self, force_crlf=False):
         """
         Renders a nacha file batch to string
         """
+        line_ending = "\n"
+        if force_crlf:
+            line_ending = "\r\n"
 
-        ret_string = self.batch_header.get_row() + "\n"
+        ret_string = self.batch_header.get_row() + line_ending
 
         for entry in self.entries:
-            ret_string += entry.render_to_string()
+            ret_string += entry.render_to_string(force_crlf=force_crlf)
 
-        ret_string += self.batch_control.get_row() + "\n"
+        ret_string += self.batch_control.get_row() + line_ending
 
         return ret_string
 
@@ -330,14 +335,17 @@ class FileEntry(object):
         if self.addenda_record:
             self.entry_detail.add_rec_ind = 1
 
-    def render_to_string(self):
+    def render_to_string(self, force_crlf=False):
         """
         Renders a nacha batch entry and addenda to string
         """
+        line_ending = "\n"
+        if force_crlf:
+            line_ending = "\r\n"
 
-        ret_string = self.entry_detail.get_row() + "\n"
+        ret_string = self.entry_detail.get_row() + line_ending
 
         for addenda in self.addenda_record:
-            ret_string += addenda.get_row() + "\n"
+            ret_string += addenda.get_row() + line_ending
 
         return ret_string

--- a/tests/test_line_endings.py
+++ b/tests/test_line_endings.py
@@ -1,0 +1,63 @@
+import nose.tools as nt
+
+from ach.builder import AchFile
+
+class TestLineEndings(object):
+    def setup(self):
+
+        self.settings = {
+            'immediate_dest' : '123456780',
+            'immediate_org' : '123456780',
+            'immediate_dest_name' : 'YOUR BANK',
+            'immediate_org_name' : 'YOUR COMPANY',
+            'company_id' : '1234567890', #tax number
+        }
+
+        self.ach_file = AchFile('A', self.settings) #file Id mod
+
+        self.entries = [
+            {
+                'type'           : '22', # type of
+                'routing_number' : '12345678',
+                'account_number' : '11232132',
+                'amount'         : '10.00',
+                'name'           : 'Alice Wanderdust',
+                'addenda' : [
+                    {
+                        'payment_related_info': 'Here is some additional information',
+                    },
+                ],
+            },
+            {
+                'type'           : '27',
+                'routing_number' : '12345678',
+                'account_number' : '234234234',
+                'amount'         : '150.00',
+                'name'           : 'Billy Holiday',
+            },
+            {
+                'type'           : '22',
+                'routing_number' : '123232318',
+                'account_number' : '123123123',
+                'amount'         : '12.13',
+                'name'           : 'Rachel Welch',
+            },
+        ]
+
+        self.ach_file.add_batch('PPD', self.entries, credits=True, debits=True)
+
+    def test_normal(self):
+        ach_output = self.ach_file.render_to_string()
+
+        rows = ach_output.split('\n')
+        nt.assert_equals(len(rows), 10)
+        for row in rows:
+            nt.assert_equals(len(row), 94)
+
+    def test_force_crlf(self):
+        ach_output = self.ach_file.render_to_string(force_crlf=True)
+
+        rows = ach_output.split('\r\n')
+        nt.assert_equals(len(rows), 10)
+        for row in rows:
+            nt.assert_equals(len(row), 94)


### PR DESCRIPTION
Our bank requires that the ACH file has CR/LF instead of only LF so I added a flag to the render_to_string for using CR/LF. 
- Add optional flag force_crlf to AchFile render_to_string.
- Also add tests for line endings.

The tests can be run by installing nose and running nosetests.

Adding a .travis.yml would maybe make sense also to get the tests run automatically (needs some setup on travis-ci.org also)

E.g

```
language: python
python:
  - "2.7"
# command to install dependencies
install:
  - pip install .
  - pip install -r requirements.txt
# command to run tests
script: nosetests
```
