### PR TITLE
Added support for CTX file

### DIFF
--- a/ach/builder.py
+++ b/ach/builder.py
@@ -90,7 +90,12 @@ class AchFile(object):
 
             entry.dfi_acnt_num = record['account_number']
             entry.amount = int(round(float(record['amount']) * 100))
-            entry.ind_name = record['name'].upper()[:22]
+
+            if std_ent_cls_code == 'CTX':
+                entry.recv_cmpy_name = record['company_name'].upper()[:16]
+            else:
+                entry.ind_name = record['name'].upper()[:22]
+
             entry.trace_num = self.settings['immediate_dest'][:8] \
                 + entry.validate_numeric_field(entry_counter, 7)
 
@@ -335,6 +340,7 @@ class FileEntry(object):
 
         if self.addenda_record:
             self.entry_detail.add_rec_ind = 1
+            self.entry_detail.num_add_recs = len(self.addenda_record)
 
     def render_to_string(self, force_crlf=False):
         """

--- a/ach/data_types.py
+++ b/ach/data_types.py
@@ -62,7 +62,7 @@ class Ach(object):
         """
         str_length = str(length)
 
-        match = re.match(r'([\w,\s,*,\\]{1,' + str_length + '})', field)
+        match = re.match(r'([\w,\s,*,\\,.,~]{1,' + str_length + '})', field)
 
         if match:
             if len(match.group(1)) < length:

--- a/ach/data_types.py
+++ b/ach/data_types.py
@@ -62,7 +62,7 @@ class Ach(object):
         """
         str_length = str(length)
 
-        match = re.match(r'([\w,\s]{1,' + str_length + '})', field)
+        match = re.match(r'([\w,\s,*,\\]{1,' + str_length + '})', field)
 
         if match:
             if len(match.group(1)) < length:


### PR DESCRIPTION
The current state doesn't handle CTX file correctly. So that is why I made some changes to accomplish this.
1. Support for character *\.~ in addenda record. Currently if there is one of those char in addenda, the string is truncated. CTX uses X12 EDI 820 format and those chars will appear. Source: http://www.1edisource.com/transaction-sets?TSet=820
2. Added company name in the entry because CTX uses it.
3. Added addenda record in the entry because CTX uses it.

Complete CTX details can be found here http://www.osc.nc.gov/secp/Bank_of_America_NACHA_File_Specs.pdf

Thanks in advance