### PR TITLE
Fixing issue with non-ASCII characters in README.rst

### DIFF
--- a/example.py
+++ b/example.py
@@ -41,4 +41,4 @@ entries = [
 
 ach_file.add_batch('PPD', entries, credits=True, debits=True)
 
-print ach_file.render_to_string()
+print(ach_file.render_to_string())

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
 from distutils.core import setup
+import codecs
+
+readme = codecs.open('README.rst', encoding='utf-8').read()
 
 setup(
     name='ach',
@@ -11,5 +14,5 @@ setup(
     url='https://github.com/travishathaway/python-ach',
     license='MIT License',
     description='Library to create and parse ACH files (NACHA)',
-    long_description=open('README.rst').read(),
+    long_description=readme,
 )


### PR DESCRIPTION
When I try to install python-ach module in a docker image, I get this error.
```
Running setup.py (path:/tmp/pip_build_root/ach/setup.py) egg_info for package ach
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/tmp/pip_build_root/ach/setup.py", line 14, in <module>
        long_description=open('README.rst').read(),
      File "/usr/lib/python3.4/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 234: ordinal not in range(128)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/tmp/pip_build_root/ach/setup.py", line 14, in <module>

    long_description=open('README.rst').read(),

  File "/usr/lib/python3.4/encodings/ascii.py", line 26, in decode

    return codecs.ascii_decode(input, self.errors)[0]

UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 234: ordinal not in range(128)

```
This is an issue with non-ASCII characters being in the README. We can fix this by using codecs.open('README.rst', encoding='utf-8').read() instead of open('README.rst').read() (the change is both python3 and python2 compatible).

Similar to this issue on urllib3:
https://github.com/shazow/urllib3/pull/823