### PR TITLE
fixed setup.py for windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(
     url='https://github.com/travishathaway/python-ach',
     license='MIT License',
     description='Library to create and parse ACH files (NACHA)',
-    long_description=open('README.rst').read(),
+    long_description=open('README.rst', encoding='utf-8').read(),
 )


### PR DESCRIPTION
Installing with pip on windows fails with `UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d`
Specifying `encoding='utf-8'` fixes this problem